### PR TITLE
Heap sparse la

### DIFF
--- a/experimental/HeapSparseLA/src/CombinatorialNumberSystem.jl
+++ b/experimental/HeapSparseLA/src/CombinatorialNumberSystem.jl
@@ -10,13 +10,16 @@
 
 """ Encode simplex `xs` (ascendingly sorted list of 0-based vertices) in CNS."""
 function encode(xs::Vector{Int})
+  @req all(xs .> 0) "Can only decode positive numbers."
 	@req issorted(xs) "xs must be sorted" #TODO Remove for efficiency?
-	sum(binomial(v - 1, i) for (i, v) in enumerate(xs))
+	sum(binomial(v - 1, i) for (i, v) in enumerate(xs)) + 1
 end
 
 import Base.Iterators.countfrom
 """ Decode a `dim`-dimensional simplex from CNS. Returns ascendingly sorted list of 1-indexed vertices."""
 function decode(σ::Int, dim::Int)
+  @req σ > 0 "Can only decode positive numbers."
+  σ -= 1
 	xs = Vector{Int}(undef, dim + 1) # The decoded vertices
 	i = dim + 1 # Index of the decoded vertex in xs
 	while i >= 1
@@ -34,9 +37,11 @@ end
 
 """ Returns the encoded faces of an encoded, `dim`-dimensional simplex in ascending order."""
 function faces(σ::Int, dim::Int)
+  @req σ > 0 "Can only decode positive numbers."
 	if dim == 0
 		return Vector{Int}()
 	end
+  σ -= 1
 	fs = Vector{Int}() # faces
 	sizehint!(fs, dim + 1)
 	ρ = 0::Int

--- a/experimental/HeapSparseLA/src/CombinatorialNumberSystem.jl
+++ b/experimental/HeapSparseLA/src/CombinatorialNumberSystem.jl
@@ -1,0 +1,57 @@
+# The combinatorial number system can encode a k-set of non-negative integers (viz an abstract simplex)
+# between 1 and N by integers between 1 and binom(N, k).
+# For compatibility reasons, we let vertices be 1-based, and the CNS encoding be 0-based.
+# For combinatorial number system, see https://en.wikipedia.org/wiki/Combinatorial_number_system
+# Algorithms taken from https://gitlab.com/flenzen/2pac/-/blob/main/CliqueComplex.cpp
+
+#TODO Replace binomial by look-up-table version.
+#TODO Replace Int by UInt
+#TODO Maybe change to 1-based CNS encoding.
+
+""" Encode simplex `xs` (ascendingly sorted list of 0-based vertices) in CNS."""
+function encode(xs::Vector{Int})
+	@req issorted(xs) "xs must be sorted" #TODO Remove for efficiency?
+	sum(binomial(v - 1, i) for (i, v) in enumerate(xs))
+end
+
+import Base.Iterators.countfrom
+""" Decode a `dim`-dimensional simplex from CNS. Returns ascendingly sorted list of 1-indexed vertices."""
+function decode(σ::Int, dim::Int)
+	xs = Vector{Int}(undef, dim + 1) # The decoded vertices
+	i = dim + 1 # Index of the decoded vertex in xs
+	while i >= 1
+		v = 1::Int # The next decoded vertex is the largest v with binom(v, i) <= σ
+		while binomial(v - 1, i) <= σ
+			v += 1
+		end
+		v -= 1
+		xs[i] = v
+		σ -= binomial(v - 1, i) # Now σ = {σ[1], ..., σ[i-1]}
+		i -= 1
+	end
+	return xs
+end
+
+""" Returns the encoded faces of an encoded, `dim`-dimensional simplex in ascending order."""
+function faces(σ::Int, dim::Int)
+	if dim == 0
+		return Vector{Int}()
+	end
+	fs = Vector{Int}() # faces
+	sizehint!(fs, dim + 1)
+	ρ = 0::Int
+	i = dim + 1 # Index of vertex in simplex
+	while i >= 1
+		# Decode σ
+		v = 1
+		while binomial(v - 1, i) <= σ
+			v += 1
+		end
+		v -= 1
+		σ -= binomial(v - 1, i)
+		push!(fs, ρ + σ) # The new face is [...,σ[i-1], σ[i+1],...]
+		i -= 1
+		ρ += binomial(v - 1, i)
+	end
+	return fs
+end

--- a/experimental/HeapSparseLA/src/HeapSparseLA.jl
+++ b/experimental/HeapSparseLA/src/HeapSparseLA.jl
@@ -3,6 +3,7 @@
 # for sorting is expensive.
 include("Types.jl")
 include("HeapDictSRow.jl")
+include("VietorisRipsComplex.jl")
 
 ### `HeapNode`
 # A minimal data structure for nodes in binary trees holding the data

--- a/experimental/HeapSparseLA/src/VietorisRipsComplex.jl
+++ b/experimental/HeapSparseLA/src/VietorisRipsComplex.jl
@@ -1,0 +1,141 @@
+# Generates the coboundary matrices of a diameter-filtered Vietoris-Rips complex.
+# A Vietoris-Rips complex on a point cloud X is the abstract simplicial complex
+# VR(X) ≔ 2^X. It is filtered by the diameter diam σ ≔ max{d(x, y) | x, y ∈ σ}.
+# In practise, one truncates VR(X) at a fixed threshold t, i.e.,
+# VR(X) ≔ {σ ∈ 2^X | diam σ ≤ t}.
+
+#TODO Use UInt instead of Int, where applicable.
+#TODO Take diameter into consideration
+
+include("CombinatorialNumberSystem.jl")
+
+""" Represents one stage during the computation of Vietoris-Rips coboundary maps."""
+struct VietorisRipsComplex
+	distances::Array{Float64, 2}
+	neighbors::Vector{Vector{Int}}
+	dimension::Int
+	simplices::Vector{Int}
+	diameters::Vector{Int}
+end
+
+"""
+	vietoris_rips_complex(distances[, threshold])
+	
+Creates a new Vietoris-Rips complex. """
+function vietoris_rips_complex(distances::Array{Float64, 2}, threshold = Inf::Float64)
+	@req is_symmetric(distances) && all(distances .>= 0) "Matrix must be a distance matrix"
+	n = size(distances, 1)
+	VietorisRipsComplex(
+		distances,
+		[[j for j in 1:n if distances[i, j] <= threshold && i != j] for i in 1:n],
+		# [sort([j for j in 1:n if distances[i, j] <= threshold && i != j], by=j->distances[i,j]) for i in 1:n],
+		0,
+		collect(1:n),
+		[0 for _ in 0:n-1],
+	)
+end
+
+
+"""
+	coboundary_map(K :: VietorisRipsComplex)
+	
+Computes the next coboundary map of a Vietoris-Rips complex.
+
+Returns the next piece of data, plus the actual coboundary matrix.
+
+# Examples
+```jldoctest
+julia> distance_matrix = [0.0 1.0 2.0 3.0; 1.0 0.0 1.0 2.0; 2.0 1.0 0.0 1.0; 3.0 2.0 1.0 0.0];
+
+julia> V = vietoris_rips_complex(distance_matrix);
+
+julia> V, δ0 = coboundary_map(V); δ0
+[ 1    1    0    1    0    0]
+[-1    0    1    0    1    0]
+[ 0   -1   -1    0    0    1]
+[ 0    0    0   -1   -1   -1]
+
+julia> V, δ1 = coboundary_map(V); δ1
+[ 1    1    0    0]
+[-1    0    1    0]
+[ 1    0    0    1]
+[ 0   -1   -1    0]
+[ 0    1    0   -1]
+[ 0    0    1    1]
+```"""
+function coboundary_map(K::VietorisRipsComplex)
+	# Algorithm taken from https://gitlab.com/flenzen/2pac/-/blob/main/CliqueComplex.cpp
+	coboundary_columns = [Vector{Tuple{Float64, Int, Int}}() for _ in 1:length(K.simplices)]
+	simplices_next_dim = Vector{Int}()
+	diameters_next_dim = Vector{Float64}()
+	index_of_simplex_next_dim = Dict{Int, Int}()
+
+	for (column_index, (σ, diam)) in enumerate(zip(K.simplices, K.diameters))
+		if K.dimension == 0
+			# σ = {v} = v is a vertex.
+			for n in K.neighbors[σ]
+				coface = encode(sort([σ, n]))
+				diameter = K.distances[σ, n]
+				push!(coboundary_columns[column_index], (diameter, coface, n < σ ? -1 : 1))
+			end
+		else
+			# σ = encode(xs) is a higher dimensional simplex
+			xs = decode(σ, K.dimension)
+			# Iterate through neighbors of ith and i+1st vertex in xs in parallel until a common neighbour is found.
+			# If indices[i] has been incremented, it is out of sync with neighbor of i-1st vertex. Therefore, continue with i-1 and i.
+			# Otherwise, continue with i+1, i+2. Eventually, we have a common neighbor of all vertices in σ,
+			# viz the apex of a coface.
+			neighbor_indices = [1 for _ in 1:length(xs)]
+			i = 1
+			while neighbor_indices[i] <= length(K.neighbors[xs[i]]) && neighbor_indices[i+1] <= length(K.neighbors[i+1])
+				if K.neighbors[xs[i]][neighbor_indices[i]] < K.neighbors[xs[i+1]][neighbor_indices[i+1]]
+					# The i-th neighbor index is behind
+					neighbor_indices[i] += 1
+					if i > 1
+						i -= 1
+					end
+				elseif K.neighbors[xs[i]][neighbor_indices[i]] > K.neighbors[xs[i+1]][neighbor_indices[i+1]]
+					neighbor_indices[i+1] += 1
+				elseif (i += 1) == length(xs)
+					# All indices[1],...,indices[i] point to the same common neighbor of all vertices xs,
+					# so we have found a coface of σ
+					apex = K.neighbors[xs[i]][neighbor_indices[i]]
+					diameter = maximum(K.distances[v, apex] for v in xs; init = diam)
+					coface = encode(sort([xs; [apex]]))
+					coeff = 1
+					for v in xs
+						if v > apex
+							break
+						else
+							coeff *= -1
+						end
+					end
+					push!(coboundary_columns[column_index], (diameter, coface, coeff))
+					# Continue with finding more cofaces
+					i = 1
+					neighbor_indices[i] += 1
+				end
+			end
+			# At this point, there are no more cofaces
+		end
+	end
+
+	new_simplices = sort(collect(Set(σ for column in coboundary_columns for (_, σ, _) in column)))
+
+	#TODO Replace by (heap)-sparse matrix
+	dense_mat = zero_matrix(QQ, length(K.simplices), length(new_simplices))
+	for (j, column) in enumerate(coboundary_columns)
+		for (_, i, coeff) in column
+			dense_mat[j, i+1] = coeff
+		end
+	end
+
+	return VietorisRipsComplex(
+		K.distances,
+		K.neighbors,
+		K.dimension + 1,
+		new_simplices,
+		[0.0 for _ in 1:length(new_simplices)],
+	), dense_mat
+end
+

--- a/experimental/HeapSparseLA/test/CombinatorialNumberSystem.jl
+++ b/experimental/HeapSparseLA/test/CombinatorialNumberSystem.jl
@@ -1,0 +1,5 @@
+@testset "Combinatorial number system: encoding and decoding" begin
+	s = [2, 6, 9, 11]
+	@test s == Oscar.decode(Oscar.encode(s), length(s) - 1)
+	@test 49 == Oscar.encode(Oscar.decode(49, 3))
+end

--- a/experimental/HeapSparseLA/test/VietorisRipsComplex.jl
+++ b/experimental/HeapSparseLA/test/VietorisRipsComplex.jl
@@ -1,0 +1,17 @@
+using LinearAlgebra
+
+@testset "Vietoris Rips coboundary maps" begin
+	# Generate random points and compute their distance matrix
+	# See https://samuelalbanie.com/files/Euclidean_distance_trick.pdf for the computation of the distance matrix
+	p = rand(10, 3)
+	gram = p * p'
+	distances = sqrt.(diag(gram) .+ diag(gram)' .- 2 .* gram)
+	# Generate the Vietoris-Rips coboundary matrices and check that they have coboundary property
+	V = Oscar.vietoris_rips_complex(distances)
+	δ = zero_matrix(QQ, 0, length(V.simplices))
+	for _ in 1:5
+		V, δ2 = Oscar.coboundary_map(V)
+		@test iszero(δ * δ2)
+		δ = δ2
+	end
+end

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -143,3 +143,5 @@ end
   @test T0*B0 == A
 end
 
+include("CombinatorialNumberSystem.jl")
+include("VietorisRipsComplex.jl")


### PR DESCRIPTION
Added code to compute the coboundary matrices of Vietoris–Rips complexes. At the moment, the matrices returned are dense, but that should be straightforward to change (`VietorisRipsComplex.jl`, l. 144).