### PR TITLE
Support for vector_space_dim and friends for  modules over MPoly(Quo)LocRing localized at a point 

### DIFF
--- a/experimental/Schemes/src/Tjurina.jl
+++ b/experimental/Schemes/src/Tjurina.jl
@@ -782,7 +782,7 @@ by submodule with 7 generators
   7: x*y*e[2]
 
 julia> vector_space_basis(T)
-5-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
+5-element Vector{SubquoModuleElem{MPolyLocRingElem{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem, MPolyComplementOfKPointIdeal{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem}}}}:
  e[1]
  e[2]
  y*e[1]

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -637,8 +637,9 @@ function vector_space_dim(kk::Field, M::SubquoModule; check::Bool=true)
   F = ambient_free_module(M)
   # We need `M` to be presented  
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
-    pres = presentation(M)
-    MM = cokernel(map(pres, 1))
+    # pres = presentation(M)
+    # MM = cokernel(map(pres, 1))    # cokernel sometimes returns also the canonical projection
+    MM = present_as_cokernel(M)
     return _vector_space_dim(kk, MM; check)
   end
   # At this point we may assume `M` to be presented
@@ -729,11 +730,15 @@ function vector_space_basis(kk::Field, M::SubquoModule; check::Bool=true)
   F = ambient_free_module(M)
   # We need `M` to be presented  
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
-    pres = presentation(M)
-    MM = cokernel(map(pres, 1))
+    # pres = presentation(M)
+    # MM = cokernel(map(pres, 1))    # cokernel sometimes returns also the canonical projection
+    MM = present_as_cokernel(M)
     B = _vector_space_basis(kk, MM; check)
-    aug = map(pres, 0)
-    return elem_type(M)[aug(pres[0](coordinates(v))) for v in B]
+    # aug = map(pres, 0)
+    pres0 = ambient_free_module(MM)
+    aug = hom(pres0, M, gens(M))
+    # return elem_type(M)[aug(pres[0](coordinates(v))) for v in B]
+    return elem_type(M)[aug(pres0(coordinates(v))) for v in B]
   end
   
   # If execution gets here, `M` is presented.

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -1141,3 +1141,28 @@ end
 function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyLocRingElem}
   error("only available in global case and for localization at a point")
 end
+
+### functionality for modules over quotients of localized polynomial rings at a point
+function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T<:MPolyQuoLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, <:MPolyComplementOfKPointIdeal}}
+ R = base_ring(M)
+  @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the underlying polynomial ring"
+  @check _is_finite(kk, M) "module is not finite over the given field"
+  B = _vector_space_basis(kk, _as_polyloc_module(M), check=false)
+  is_empty(B) && return elem_type(M)[]
+  iota = _iso_with_polyloc_module(M)
+  return iota.(B)
+end
+
+function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T<:MPolyQuoLocRingElem}
+   error("only available in global case and for localization at a point")
+end
+
+function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyQuoLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
+                               <:MPolyComplementOfKPointIdeal}}
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
+  return _is_finite(kk, _as_polyloc_module(M))
+end
+
+function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyQuoLocRingElem}
+  error("only available in global case and for localization at a point")
+end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -879,19 +879,19 @@ function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::Int64; check:
   error("not implemented")
 end
   
-function vector_space_dim(M::SubquoModule{T}
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
-                               <:MPolyComplementOfKPointIdeal}}
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
+# function vector_space_dim(M::SubquoModule{T}
+#   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
+#                                <:MPolyComplementOfKPointIdeal}}
+#   F = ambient_free_module(M)
+#   Mq,_ = sub(F,rels(M))
 
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
+#   ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
 
-  M_shift,_,_ = shifted_module(Mq)
-  o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
-  LM = leading_module(M_shift,o)
-  return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)))
-end
+#   M_shift,_,_ = shifted_module(Mq)
+#   o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
+#   LM = leading_module(M_shift,o)
+#   return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)))
+# end
 
 function vector_space_dim(
     M::SubquoModule{T}, d::Int64;
@@ -909,34 +909,34 @@ function vector_space_dim(
   return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)),d)
 end
 
-function vector_space_dim(M::SubquoModule{T}; check::Bool=true
-  ) where {T<:MPolyLocRingElem}
-  error("only available in global case and for localization at a point")
-end
+# function vector_space_dim(M::SubquoModule{T}; check::Bool=true
+#   ) where {T<:MPolyLocRingElem}
+#   error("only available in global case and for localization at a point")
+# end
 
 function vector_space_dim(M::SubquoModule{T}, d::Int64
   ) where {T<:MPolyLocRingElem}
   error("only available in global case and for localization at a point")
 end
 
-function vector_space_basis(M::SubquoModule{T}
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
-                               <:MPolyComplementOfKPointIdeal}}
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
+# function vector_space_basis(M::SubquoModule{T}
+#   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
+#                                <:MPolyComplementOfKPointIdeal}}
+#   F = ambient_free_module(M)
+#   Mq,_ = sub(F,rels(M))
 
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
+#   ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
 
-  M_shift,_,_ = shifted_module(Mq)
-  if isdefined(F,:ordering) && is_local(F.ordering)
-    o = F.ordering
-  else
-    o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
-  end
-  LM = leading_module(M_shift,o)
+#   M_shift,_,_ = shifted_module(Mq)
+#   if isdefined(F,:ordering) && is_local(F.ordering)
+#     o = F.ordering
+#   else
+#     o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
+#   end
+#   LM = leading_module(M_shift,o)
 
-  return vector_space_basis(quo_object(ambient_free_module(LM),gens(LM)))
-end
+#   return vector_space_basis(quo_object(ambient_free_module(LM),gens(LM)))
+# end
 
 function vector_space_basis(M::SubquoModule{T},d::Int64
   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
@@ -957,10 +957,10 @@ function vector_space_basis(M::SubquoModule{T},d::Int64
   return vector_space_basis(quo_object(ambient_free_module(LM),gens(LM)),d)
 end
 
-function vector_space_basis(M::SubquoModule{T}
-  ) where {T<:MPolyLocRingElem}
-  error("only available in global case and for localization at a point")
-end
+# function vector_space_basis(M::SubquoModule{T}
+#   ) where {T<:MPolyLocRingElem}
+#   error("only available in global case and for localization at a point")
+# end
 
 function vector_space_basis(M::SubquoModule{T},d::Int64
   ) where {T<:MPolyLocRingElem}
@@ -1101,3 +1101,38 @@ function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyQuoRingElem{<:
   return _is_finite(kk, _as_poly_module(M))
 end
 
+### functionality for modules over localized polynomial rings at a point
+function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, <:MPolyComplementOfKPointIdeal}}
+  R = base_ring(M)
+  @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the underlying polynomial ring"
+  @check _is_finite(kk, M) "module is not finite over the given field"
+  F = ambient_free_module(M)
+  Mq,_ = sub(F,relations(M))
+  Mq_shift,_,_= Oscar.shifted_module(Mq)
+  o = negdegrevlex(base_ring(Mq_shift))*lex(ambient_free_module(Mq_shift))
+  LMq = leading_module(Mq_shift, o)
+  B = _vector_space_basis(kk, quo_object(ambient_free_module(LMq), gens(LMq)), check=false)
+  is_empty(B) && return elem_type(M)[]
+  _,back_shift = Oscar.base_ring_shifts(R)
+  iota = hom(parent(B[1]), M, gens(M), a -> R(back_shift(a)))
+  return iota.(B)
+end
+
+function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T<:MPolyLocRingElem}
+   error("only available in global case and for localization at a point")
+end
+
+function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
+                               <:MPolyComplementOfKPointIdeal}}
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
+  F = ambient_free_module(M)
+  Mq,_ = sub(F,rels(M))
+  Mq_shift,_,_ = shifted_module(Mq)
+  o = negdegrevlex(base_ring(Mq_shift))*lex(ambient_free_module(Mq_shift))
+  LMq = leading_module(Mq_shift, o)
+  return _is_finite(kk, quo_object(ambient_free_module(LMq), gens(LMq)))
+end
+
+function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyLocRingElem}
+  error("only available in global case and for localization at a point")
+end

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -123,3 +123,122 @@ function kernel(
   K, inc = sub(domain(f), C)
   return K, inc
 end
+
+
+########################################################################
+# lifting base_ring from MPolyQuoLocRing to MPolyLocRing               #
+########################################################################
+
+# MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST}
+
+#
+### For a free module F = R^r over R = P/I, this returns a lifting map 
+# to the module P^r/I*P^r. Note that this is an unnatural map since 
+# the latter is an R-module only by accident.
+@attr Any function _lifting_iso(F::FreeMod{T}) where {T<:MPolyQuoLocRingElem}
+  M = _as_polyloc_module(F)
+  function my_lift(v::FreeModElem{T}) where {T<:MPolyQuoLocRingElem}
+    parent(v) === F || error("element does not have the right parent")
+    w = elem_type(M)[lift(a)*M[i] for (i, a) in coordinates(v)]
+    iszero(length(w)) && return zero(M)
+    return sum(w)
+  end
+  return my_lift
+end
+
+### For a free module F = R^r over R = P/I, this returns a lifting map 
+# to the module P^r. Note that this is not a homomorphism of modules. 
+@attr Any function _lifting_map(F::FreeMod{T}) where {T<:MPolyQuoLocRingElem}
+  FP = _polyloc_module(F)
+  function my_lift(v::FreeModElem{T}) where {T<:MPolyQuoLocRingElem}
+    parent(v) === F || error("element does not have the right parent")
+    w = [lift(a)*FP[i] for (i, a) in coordinates(v)]
+    iszero(length(w)) && return zero(FP)
+    return sum(w)
+  end
+  return my_lift
+end
+
+### To a free module over R = P/I, return the free module over R 
+# in the same number of generators
+@attr FreeMod{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _polyloc_module(F::FreeMod{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+  R = base_ring(F)
+  P = localized_ring(R) # the polyloc ring
+  r = rank(F)
+  FP = FreeMod(P, r) 
+  return FP
+end
+
+### Return the canonical projection FP -> F from the P-module FP to the 
+# R-module F.
+@attr FreeModuleHom{FreeMod{T}, FreeMod{MPolyQuoLocRingElem{T}}, MPolyQuoLocRing{T}} function _polyloc_module_restriction(F::FreeMod{MPolyQuoLocRingElem{T}}) where {T}
+  R = base_ring(F)
+  P = localized_ring(R)
+  FP = _polyloc_module(F)
+  return hom(FP, F, gens(F), R)
+end
+
+### Return the same module, but as a SubquoModule over the localized polynomial ring
+@attr SubquoModule{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _as_polyloc_module(F::FreeMod{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+  R = base_ring(F)
+  P = localized_ring(R)
+  I = modulus(R)
+  FP = FreeMod(P, rank(F))
+  IFP, inc = I*FP
+  M, p = quo(FP, IFP)
+  # # Manually set a groebner basis
+  # # This is brittle! Please improve!
+  # J = ideal(P, gens(groebner_basis(I))) # a groebner basis has already been computed.
+  # JFP, _ = J*FP
+  # G, _ = quo(FP, JFP)
+  # gb = G.quo.gens
+  # ord = default_ordering(M.quo)
+  # gb.ordering = ord
+  # gb.isGB = true
+  # singular_generators(gb).isGB = true
+  # M.quo.groebner_basis[ord] = gb
+  return M
+end
+
+### Return an isomorphism with _as_polyloc_module(F)
+@attr Any function _iso_with_polyloc_module(F::FreeMod{T}) where {T<:MPolyQuoLocRingElem}
+  M = _as_polyloc_module(F)
+  return hom(M, F, gens(F), base_ring(F))
+end
+
+### Return the preimage of M under the canonical projection P^r -> R^r 
+# for R^r the ambient_free_module of M.
+@attr Any function _polyloc_module(M::SubModuleOfFreeModule{T}) where {T<:MPolyQuoLocRingElem}
+  F = ambient_free_module(M) 
+  FP = _polyloc_module(F)
+  v = elem_type(FP)[_lifting_map(F)(g) for g in gens(M)] 
+  w = elem_type(FP)[f*e for e in gens(FP) for f in gens(modulus(base_ring(M)))]
+  MP = SubModuleOfFreeModule(FP, vcat(v, w))
+  return MP
+end
+
+@attr SubquoModule{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _as_polyloc_module(M::SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+  F = ambient_free_module(M) 
+  FP = _polyloc_module(F)
+  v = [_lifting_map(F)(g) for g in ambient_representatives_generators(M)] 
+  w = [f*e for e in gens(FP) for f in gens(modulus(base_ring(M)))]
+  w_ext = vcat(w, elem_type(FP)[_lifting_map(F)(g) for g in relations(M)])
+  MP = SubquoModule(FP, v, w_ext)
+  return MP
+end
+
+@attr SubQuoHom{SubquoModule{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}}, SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}, MPolyQuoLocRing{BRT, BRET, RT, RET, MST}} function _iso_with_polyloc_module(F::SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+  M = _as_polyloc_module(F)
+  return hom(M, F, gens(F), base_ring(F))
+end
+
+@attr Any function _lifting_iso(F::SubquoModule{T}) where {T<:MPolyQuoLocRingElem}
+  M = _as_polyloc_module(F)
+  function my_lift(v::SubquoModuleElem{T}) where {T<:MPolyQuoLocRingElem}
+    parent(v) === F || error("element does not have the right parent")
+    w = elem_type(M)[lift(a)*M[i] for (i, a) in coordinates(v)]
+    iszero(length(w)) && return zero(M)
+    return sum(w)
+  end
+  return my_lift
+end

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -161,7 +161,7 @@ end
 
 ### To a free module over R = P/I, return the free module over R 
 # in the same number of generators
-@attr FreeMod{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _polyloc_module(F::FreeMod{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+@attr FreeMod{MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _polyloc_module(F::FreeMod{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
   R = base_ring(F)
   P = localized_ring(R) # the polyloc ring
   r = rank(F)
@@ -179,7 +179,7 @@ end
 end
 
 ### Return the same module, but as a SubquoModule over the localized polynomial ring
-@attr SubquoModule{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _as_polyloc_module(F::FreeMod{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+@attr SubquoModule{MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _as_polyloc_module(F::FreeMod{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
   R = base_ring(F)
   P = localized_ring(R)
   I = modulus(R)
@@ -217,17 +217,17 @@ end
   return MP
 end
 
-@attr SubquoModule{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _as_polyloc_module(M::SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+@attr SubquoModule{MPolyLocRingElem{BRT, BRET, RT, RET, MST}} function _as_polyloc_module(M::SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
   F = ambient_free_module(M) 
   FP = _polyloc_module(F)
-  v = [_lifting_map(F)(g) for g in ambient_representatives_generators(M)] 
-  w = [f*e for e in gens(FP) for f in gens(modulus(base_ring(M)))]
+  v = elem_type(FP)[_lifting_map(F)(g) for g in ambient_representatives_generators(M)] 
+  w = elem_type(FP)[f*e for e in gens(FP) for f in gens(modulus(base_ring(M)))]
   w_ext = vcat(w, elem_type(FP)[_lifting_map(F)(g) for g in relations(M)])
   MP = SubquoModule(FP, v, w_ext)
   return MP
 end
 
-@attr SubQuoHom{SubquoModule{<:MPolyLocRingElem{BRT, BRET, RT, RET, MST}}, SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}, MPolyQuoLocRing{BRT, BRET, RT, RET, MST}} function _iso_with_polyloc_module(F::SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
+@attr SubQuoHom{SubquoModule{MPolyLocRingElem{BRT, BRET, RT, RET, MST}}, SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}, MPolyQuoLocRing{BRT, BRET, RT, RET, MST}} function _iso_with_polyloc_module(F::SubquoModule{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST}
   M = _as_polyloc_module(F)
   return hom(M, F, gens(F), base_ring(F))
 end

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2670,6 +2670,8 @@ function is_homogeneous(a::MPolyQuoLocRingElem{<:Ring, <:RingElem, <:MPolyDecRin
   return is_homogeneous(numerator(a)) && is_homogeneous(denominator(a))
 end
 
+coefficient_ring(L::MPolyQuoLocRing) = coefficient_ring(base_ring(L))
+
 ########################################################################
 # Inverses of homomorphisms                                            #
 ########################################################################

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2045,10 +2045,55 @@ end
   @test vector_space_basis(O2) == elem_type(O2)[]
   @test typeof(vector_space_basis(O2)) == typeof(elem_type(O2)[])
 
-  # quotient of free_module (S_6 space_curve with translated singularity to (1,2,3))
+  # quotient of free_module (S_6 space_curve with singularity translated to (1,2,3))
   rels = [
     ((x-1)^3+(y-2)^2+(z-3)^2)*F[1], ((x-1)*(y-2))*F[1],
     ((x-1)^3+(y-2)^2+(z-3)^2)*F[2], ((x-1)*(y-2))*F[2],
+    3*(x-1)^2*F[1] + (y-2)*F[2],
+    2*(y-2)*F[1] + (x-1)*F[2],
+    2*(z-3)*F[1]
+  ]
+  S = SubquoModule(F, [F[1], F[2]], rels)
+  @test vector_space_dim(S) == 6
+  B = vector_space_basis(S)
+  @test length(B) == 6
+  @test all(b -> parent(b) === S, B)
+  #the computed basis depends on the default monomial order of R
+  @test all(b -> b in repres.(B), [F[1], F[2], (x-1)*F[1], (x-1)^2*F[1], (y-2)*F[1], (z-3)*F[2]]) 
+
+  # quotient of a submodule 
+  T = SubquoModule(F, [(x-1)*F[1], (y-2)*F[2]], rels)
+  @test vector_space_dim(T) == 2
+  C = vector_space_basis(T)
+  @test length(C) == 2
+  @test all(c -> parent(c) === T, C)
+  @test all(c -> c in repres.(C), [(x-1)*F[1], (x-1)^2*F[1]])
+
+  # computing basis for infinite dimensional vector space throws error
+  S = SubquoModule(F, gens(F), [F[1]])
+  # not a finite module over `QQ`
+  @test_throws ErrorException vector_space_basis(S)
+end
+
+@testset "vector space functions for modules over a MPolyQuoLocRing" begin
+  R, (x,y,z) = QQ[:x,:y,:z]
+  I = ideal(R, [(x-1)^3+(y-2)^2+(z-3)^2, (x-1)*(y-2)])
+  Q,_ = quo(R, I)
+  LQ,_ =  localization(Q, complement_of_point_ideal(R, [1,2,3]))
+  F = free_module(LQ, 2)
+  # different presentations of the zero module
+  O1 = quo_object(F, gens(F))
+  @test vector_space_dim(O1) == 0
+  @test vector_space_basis(O1) == elem_type(O1)[]
+  @test typeof(vector_space_basis(O1)) == typeof(elem_type(O1)[])
+
+  O2 = SubquoModule(F, elem_type(F)[])
+  @test vector_space_dim(O2) == 0
+  @test vector_space_basis(O2) == elem_type(O2)[]
+  @test typeof(vector_space_basis(O2)) == typeof(elem_type(O2)[])
+
+  # quotient of free_module (S_6 space_curve with singularity translated to (1,2,3))
+  rels = [
     3*(x-1)^2*F[1] + (y-2)*F[2],
     2*(y-2)*F[1] + (x-1)*F[2],
     2*(z-3)*F[1]

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2029,3 +2029,48 @@ end
   # not a finite module over `QQ`
   @test_throws ErrorException vector_space_basis(S)
 end
+
+@testset "vector space functions for modules over a MPolyLocRing" begin
+  R, (x,y,z) = QQ[:x,:y,:z]
+  L,_ =  localization(R, complement_of_point_ideal(R, [1,2,3]))
+  F = free_module(L, 2)
+  # different presentations of the zero module
+  O1 = quo_object(F, gens(F))
+  @test vector_space_dim(O1) == 0
+  @test vector_space_basis(O1) == elem_type(O1)[]
+  @test typeof(vector_space_basis(O1)) == typeof(elem_type(O1)[])
+
+  O2 = SubquoModule(F, elem_type(F)[])
+  @test vector_space_dim(O2) == 0
+  @test vector_space_basis(O2) == elem_type(O2)[]
+  @test typeof(vector_space_basis(O2)) == typeof(elem_type(O2)[])
+
+  # quotient of free_module (S_6 space_curve with translated singularity to (1,2,3))
+  rels = [
+    ((x-1)^3+(y-2)^2+(z-3)^2)*F[1], ((x-1)*(y-2))*F[1],
+    ((x-1)^3+(y-2)^2+(z-3)^2)*F[2], ((x-1)*(y-2))*F[2],
+    3*(x-1)^2*F[1] + (y-2)*F[2],
+    2*(y-2)*F[1] + (x-1)*F[2],
+    2*(z-3)*F[1]
+  ]
+  S = SubquoModule(F, [F[1], F[2]], rels)
+  @test vector_space_dim(S) == 6
+  B = vector_space_basis(S)
+  @test length(B) == 6
+  @test all(b -> parent(b) === S, B)
+  #the computed basis depends on the default monomial order of R
+  @test all(b -> b in repres.(B), [F[1], F[2], (x-1)*F[1], (x-1)^2*F[1], (y-2)*F[1], (z-3)*F[2]]) 
+
+  # quotient of a submodule 
+  T = SubquoModule(F, [(x-1)*F[1], (y-2)*F[2]], rels)
+  @test vector_space_dim(T) == 2
+  C = vector_space_basis(T)
+  @test length(C) == 2
+  @test all(c -> parent(c) === T, C)
+  @test all(c -> c in repres.(C), [(x-1)*F[1], (x-1)^2*F[1]])
+
+  # computing basis for infinite dimensional vector space throws error
+  S = SubquoModule(F, gens(F), [F[1]])
+  # not a finite module over `QQ`
+  @test_throws ErrorException vector_space_basis(S)
+end


### PR DESCRIPTION
@HechtiDerLachs feel free to decide whether to include this in your current open PR or not, since it is already late and the deadline for the 1.7.0 release is approaching quickly. 

To sum up the changes in this PR:
- refactores the existing code for the ungraded `MPolyLocRing` case and extends it to modules with true sub part (left the old code commented out)
- in doing so swiches to using 'present_as_cokernel` instead of `cokernel` when presenting the module, since the later one sometimes also returns the canonical projection
- also left the code for the "total degree graded" `MPolyLocRing` case untouched, since there are two test in an old testset, that would break otherwise  (should probably be removed)

- copys and refactors the "base_ring_lift" -functions for modules over a `MPolyQuoRing` to the case of modules over a`MPolyQuoLocRing`
- adds full support for ungraded modules over a `MPolyQuoLocRing`
